### PR TITLE
Remove trailing slash from end of url when storing it into local storage

### DIFF
--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -19,6 +19,10 @@ export const getQueryStringFromUrl = (url: string) => {
   return params.get(config.apiEndpoint);
 };
 
+export const RemoveLastTrailingSlashFromString = (word: string) => {
+  return word.replace(/\/$/, '');
+};
+
 export const removeSpaceFromString = (url: string) => {
   return url.replace(/\s/g, '');
 };
@@ -37,14 +41,16 @@ export const matchEndpointProtocolWithHostProtocol = (url: string) => {
 
   if (!apiEndpointProtocol) {
     const newApiEndpointWithProtocol  = `${hostProtocol}//${url}`;
-     const cleanURL = removeSpaceFromString(newApiEndpointWithProtocol);
-     localStorage.setItem(config.apiEndpoint, cleanURL);
+    const trimmedUrl = removeSpaceFromString(newApiEndpointWithProtocol);
+    const cleanUrl = RemoveLastTrailingSlashFromString(trimmedUrl);
+     localStorage.setItem(config.apiEndpoint, cleanUrl);
   }
 
   if (hostProtocol !== apiEndpointProtocol) {
     const matchedUrlProtocol = url.replace(apiEndpointProtocol, hostProtocol);
-    const cleanURL = removeSpaceFromString(matchedUrlProtocol);
-    localStorage.setItem(config.apiEndpoint, cleanURL);
+     const trimmedUrl = removeSpaceFromString(matchedUrlProtocol);
+    const cleanUrl = RemoveLastTrailingSlashFromString(trimmedUrl);
+     localStorage.setItem(config.apiEndpoint, cleanUrl);
     return;
   }
 


### PR DESCRIPTION
This PR...

## Changes

- Sometimes users put url with trailing slash in the end, so we try to clean it in order to have a clean endpoint when looking for a single test.

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
