### PR TITLE
Move header organism outside of the query provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {useQuery} from 'react-query';
 
-import {TestResults, TestsFilter, TestsSummary, PageHeader} from '@organisms';
+import {TestResults, TestsFilter, TestsSummary} from '@organisms';
 import {TestsContext} from '@context/testsContext';
 
 import {getDate, getLatestDate} from '@utils/formatDate';
@@ -110,7 +110,6 @@ function App() {
   return (
     <>
       {error && 'Something went wrong...'}
-      <PageHeader />
       <TestsContext.Provider value={tests}>
         <MainTableStyles>
           <thead>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import {QueryClient, QueryClientProvider} from 'react-query';
 import {ReactQueryDevtools} from 'react-query/devtools';
 
+import {PageHeader} from '@organisms';
 import App from './App';
 import './styles/variables.css';
 import 'antd/dist/antd.css';
@@ -20,6 +21,7 @@ const queryCache = new QueryClient({
 
 ReactDOM.render(
   <React.StrictMode>
+    <PageHeader />
     <QueryClientProvider client={queryCache}>
       <GlobalStyle />
       <App />


### PR DESCRIPTION
In order to prevent the icon from refreshing, we need to place it outside of the react-query provider

This PR...

## Changes

- Adding the icon in the header to launch the modal made it to shake due to that react-query provider is wrapping the component with it, so we need to place it in a higher level outside of the provider.

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
