### PR TITLE
Hamzahsn/feat/show modal only when api does not endpoint exists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,15 @@ import styled from 'styled-components';
 import {useQuery} from 'react-query';
 
 import {TestResults, TestsFilter, TestsSummary} from '@organisms';
+import {Modal} from '@atoms';
 import {TestsContext} from '@context/testsContext';
 
 import {getDate, getLatestDate} from '@utils/formatDate';
-import {cleanStorageWhenApiEndpointQueryStringIsAbsent, getApiEndpointOnPageLoad} from '@utils/validate';
+import {
+  cleanStorageWhenApiEndpointQueryStringIsAbsent,
+  getApiEndpointOnPageLoad,
+  CheckIfQueryParamsExistsInUrl,
+} from '@utils/validate';
 
 import {config} from '@constants/config';
 import {Tests} from '@types';
@@ -47,6 +52,7 @@ function App() {
   const [selectedTimeIntervalTests, setSelectedTimeIntervalTests] = useState('');
   const [latestDateTests, setLatestDateTests] = useState<boolean>(false);
   const [testsExecution, setTestsExecution] = useState<Tests[]>([]);
+  const [visible, setVisible] = useState<boolean>(false);
 
   const {data, error} = useQuery(
     'tests',
@@ -102,14 +108,24 @@ function App() {
     }
   }, [data]);
 
-  useEffect(() => {
+  const dashboardEndpointValidators = () => {
     getApiEndpointOnPageLoad();
     cleanStorageWhenApiEndpointQueryStringIsAbsent();
+
+    const apiEndpointExist = CheckIfQueryParamsExistsInUrl(config.apiEndpoint);
+    if (!apiEndpointExist) {
+      setVisible(true);
+    }
+  };
+
+  useEffect(() => {
+    dashboardEndpointValidators();
   }, []);
 
   return (
     <>
       {error && 'Something went wrong...'}
+      {visible && <Modal visible isModalVisible={setVisible} />}
       <TestsContext.Provider value={tests}>
         <MainTableStyles>
           <thead>

--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+import {Modal} from 'antd';
+
+import {Button, LabelInput, Typography} from '@atoms';
+import {
+  validateUrl,
+  matchEndpointProtocolWithHostProtocol,
+  removeDuplicatesInQueryString,
+  checkApiEndpointProtocol,
+} from '@utils/validate';
+
+const StyledSearchUrlForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const modalStyles = {
+  backgroundColor: 'var(--color-dark-primary)',
+  height: '300px',
+  overflow: 'hidden',
+};
+
+const StyledFormContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+interface IUrlEndpoint {
+  apiEndpoint: string;
+}
+
+interface IModal {
+  isModalVisible: (isVisible: boolean) => void;
+  visible?: boolean;
+}
+
+const CustomModal = ({isModalVisible, visible}: IModal) => {
+  const [apiEndpoint, setApiEndpoint] = React.useState<IUrlEndpoint>({apiEndpoint: ''});
+  const [validUrl, setVAlidUrl] = React.useState<boolean>(false);
+
+  const handleChangeApiEndpoint = (event: React.ChangeEvent<HTMLInputElement>, field: keyof IUrlEndpoint) => {
+    setApiEndpoint({...apiEndpoint, [field]: event.target.value});
+    const validatedUrl = validateUrl(apiEndpoint.apiEndpoint);
+    setVAlidUrl(validatedUrl);
+  };
+
+  const handleOpenUrl = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+
+    removeDuplicatesInQueryString(window.location.href);
+    matchEndpointProtocolWithHostProtocol(apiEndpoint.apiEndpoint);
+
+    const checked = checkApiEndpointProtocol(apiEndpoint.apiEndpoint);
+
+    window.open(`${window.location.origin}/?apiEndpoint=${checked}`);
+  };
+
+  const handleOk = () => {
+    isModalVisible(false);
+  };
+
+  const handleCancel = () => {
+    isModalVisible(false);
+  };
+
+  return (
+    <Modal
+      title="Kubtest API endpoint"
+      visible={visible}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      footer={null}
+      bodyStyle={modalStyles}
+    >
+      <StyledSearchUrlForm onSubmit={handleOpenUrl}>
+        <Typography variant="secondary">
+          Please provide the Kubtest API endpoint for your installation, which will have been provided to you by the
+          kubtest installer.
+        </Typography>
+        <Typography variant="secondary">
+          The endpoint needs to be accessible from your browser and will be used to retrieve test results only.
+        </Typography>
+        <StyledFormContainer>
+          <LabelInput
+            id="url"
+            name="url"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleChangeApiEndpoint(event, 'apiEndpoint')}
+            defaultValue={apiEndpoint.apiEndpoint}
+          />
+          <Button type="submit" disabled={!validUrl} disableFilter>
+            Get tests
+          </Button>
+        </StyledFormContainer>
+      </StyledSearchUrlForm>
+    </Modal>
+  );
+};
+
+export default CustomModal;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -4,3 +4,4 @@ export { default as Image } from './Image/Image';
 export { default as RenderTestStatusSvgIcon } from './RenderIcons/RenderIcons';
 export { default as TestTypeIcon } from './TestTypeIcon/TestTypeIcon';
 export { default as LabelInput } from './LabelledInput/LabelledInput';
+export { default as Modal } from './Modal/Modal';

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -1,24 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import {Modal} from 'antd';
 
 import {PageTitle} from '@molecules';
-import {Button, LabelInput, Image, Typography} from '@atoms';
-
-import {
-  matchEndpointProtocolWithHostProtocol,
-  validateUrl,
-  removeDuplicatesInQueryString,
-  checkApiEndpointProtocol,
-} from '@utils/validate';
+import {Image, Modal} from '@atoms';
 
 import ParamsIcon from '@assets/docs.svg';
 import docsIcon from '@assets/questionIcon.svg';
 import githubIcon from '@assets/githubIcon.svg';
-
-interface IUrlEndpoint {
-  apiEndpoint: string;
-}
 
 const StyledPAgeHeader = styled.header`
   display: flex;
@@ -26,12 +14,6 @@ const StyledPAgeHeader = styled.header`
   justify-content: space-between;
   border-bottom: 1px solid var(--color-light-primary);
   overflow: hidden;
-`;
-
-const StyledSearchUrlForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 `;
 
 const StyledHeaderTests = styled.div`
@@ -47,49 +29,11 @@ const StyledHeaderLinksButtons = styled.div`
   margin-right: var(--space-lg);
 `;
 
-const StyledFormContainer = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
 const PageHeader = () => {
-  const [apiEndpoint, setApiEndpoint] = React.useState<IUrlEndpoint>({apiEndpoint: ''});
-  const [validUrl, setVAlidUrl] = React.useState<boolean>(false);
   const [visible, setVisible] = React.useState(false);
 
-  const modalStyles = {
-    backgroundColor: 'var(--color-dark-primary)',
-    height: '300px',
-    overflow: 'hidden',
-  };
-
-  const handleOpenUrl = (event: React.SyntheticEvent) => {
-    event.preventDefault();
-
-    removeDuplicatesInQueryString(window.location.href);
-    matchEndpointProtocolWithHostProtocol(apiEndpoint.apiEndpoint);
-
-    const checked = checkApiEndpointProtocol(apiEndpoint.apiEndpoint);
-
-    window.open(`${window.location.origin}/?apiEndpoint=${checked}`);
-  };
-
-  const handleChangeApiEndpoint = (event: React.ChangeEvent<HTMLInputElement>, field: keyof IUrlEndpoint) => {
-    setApiEndpoint({...apiEndpoint, [field]: event.target.value});
-    const validatedUrl = validateUrl(apiEndpoint.apiEndpoint);
-    setVAlidUrl(validatedUrl);
-  };
-
   const showModal = () => {
-    setVisible(true);
-  };
-
-  const handleOk = () => {
-    setVisible(false);
-  };
-
-  const handleCancel = () => {
-    setVisible(false);
+    setVisible(!visible);
   };
 
   const StyledButton = styled.div`
@@ -100,35 +44,7 @@ const PageHeader = () => {
     <StyledPAgeHeader>
       <PageTitle />
       <StyledHeaderTests>
-        <Modal
-          title="Kubtest API endpoint"
-          visible={visible}
-          onOk={handleOk}
-          onCancel={handleCancel}
-          footer={null}
-          bodyStyle={modalStyles}
-        >
-          <StyledSearchUrlForm onSubmit={handleOpenUrl}>
-            <Typography variant="secondary">
-              Please provide the Kubtest API endpoint for your installation, which will have been provided to you by the
-              kubtest installer.
-            </Typography>
-            <Typography variant="secondary">
-              The endpoint needs to be accessible from your browser and will be used to retrieve test results only.
-            </Typography>
-            <StyledFormContainer>
-              <LabelInput
-                id="url"
-                name="url"
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleChangeApiEndpoint(event, 'apiEndpoint')}
-                defaultValue={apiEndpoint.apiEndpoint}
-              />
-              <Button type="submit" disabled={!validUrl} disableFilter>
-                Get tests
-              </Button>
-            </StyledFormContainer>
-          </StyledSearchUrlForm>
-        </Modal>
+        <Modal isModalVisible={setVisible} visible={visible} />
         <StyledHeaderLinksButtons>
           <StyledButton>
             <Image src={ParamsIcon} alt="search tests" type="svg" width={30} height={30} onClick={showModal} />

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -100,3 +100,12 @@ export const checkApiEndpointProtocol = (apiEndpoint: string) => {
 export const findMatchWordInString = (word: string, string: string) => {
   return string.match(new RegExp(word, 'gi'));
 };
+
+export const CheckIfQueryParamsExistsInUrl = (queryParams: string) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const myParam = urlParams.get(queryParams);
+  if (!myParam) {
+    return;
+  }
+  return myParam;
+};


### PR DESCRIPTION
This PR...

## Changes

- This PR is about rendering the modal where user specify the api endpoint if no API were specified while opening the dashboard or no API found in localStorage.

## Fixes

-

## How to test it

-

## screenshots

- 

## Checklist

- [x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
