### PR TITLE
Format date to be displayed in american time

### DIFF
--- a/src/components/molecules/ResultsDatePicker/ResultDatePicker.tsx
+++ b/src/components/molecules/ResultsDatePicker/ResultDatePicker.tsx
@@ -52,7 +52,13 @@ const ResultDatePicker = () => {
   return (
     <StyledDateContainer>
       <Typography variant="quaternary">Results for</Typography>
-      <DatePicker size="large" style={datePickerStyles} onChange={handleDatePicker} disabled={!tests.testsExecution} />
+      <DatePicker
+        size="large"
+        style={datePickerStyles}
+        format="MM/DD/YYYY"
+        onChange={handleDatePicker}
+        disabled={!tests.testsExecution}
+      />
       <Button disabled={!toggleGetTest} onClick={getLatestDateTest}>
         Latest
       </Button>


### PR DESCRIPTION
This PR...

## Changes

- Currently the dates are displayed in American time format, but when selecting the date from the date picker, the time it displayed in EU time format inside the date picker, so we need also to display it into American time format inside the date picker.

## Fixes

- Display American time format inside the date picker after selecting the date.

## How to test it

-

## screenshots

- Previously:
<img width="514" alt="Screenshot 2021-10-13 at 01 06 09" src="https://user-images.githubusercontent.com/26152898/137040845-3af715dd-21b3-4eb8-bf40-1b1957db4a37.png">

- Now:
<img width="514" alt="Screenshot 2021-10-13 at 01 05 30" src="https://user-images.githubusercontent.com/26152898/137040857-d25786c9-a0e0-4969-9d06-ec96e4a97162.png">

## Checklist

- [x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
