### PR TITLE
fix: don't reset executionRequest while changing description

### DIFF
--- a/packages/web/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
@@ -48,16 +48,12 @@ const NameNDescription: React.FC<NameNDescriptionProps> = ({label, useUpdateEnti
 
   const onSave = () => {
     const values = form.getFieldsValue();
-
     return updateEntity({
       id: details.name,
       data: {
         ...details,
         name: values.name,
         description: values.description,
-        executionRequest: {
-          description: values.description,
-        },
       },
     })
       .then(displayDefaultNotificationFlow)


### PR DESCRIPTION
## Changes

- don't reset `executionRequest` while changing description

## Fixes

- kubeshop/testkube#4440

## How to test it

- Add variables to some Test
- Modify the Test description
- Go back to variables
- The variables are still the same *(prior this fix: the variables has been removed)*

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
